### PR TITLE
Fix import path for bitcask

### DIFF
--- a/app/go.mod
+++ b/app/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-telegram-bot-api/telegram-bot-api v4.6.4+incompatible
 	github.com/google/uuid v1.1.1
 	github.com/patrickmn/go-cache v2.1.0+incompatible
-	github.com/prologic/bitcask v0.3.5
+	git.mills.io/prologic/bitcask v0.3.5
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.4.0
 	github.com/technoweenie/multipartstreamer v1.0.1 // indirect

--- a/app/pkg/telegram/db.go
+++ b/app/pkg/telegram/db.go
@@ -2,7 +2,7 @@ package telegram
 
 import (
 	"fmt"
-	"github.com/prologic/bitcask"
+	"git.mills.io/prologic/bitcask"
 	"io"
 )
 


### PR DESCRIPTION
Project has moved to [git.mills.io/prologic/bitcask](https://git.mills.io/prologic/bitcask).

For details on why see: https://github.com/prologic

Thank you! 🙇